### PR TITLE
feat: using player names for waits

### DIFF
--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -3,3 +3,8 @@ export function passTime(ms: number): Promise<void> {
     setTimeout(res, ms)
   })
 }
+
+export function setEqual<T>(set1: Set<T>, set2: Set<T>): boolean {
+  // we need compile option "lib": "esnext" for symmetricDifference
+  return set1.symmetricDifference(set2).size === 0
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -4,6 +4,6 @@
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "declaration": true,
-    "lib": ["dom"]
+    "lib": ["dom", "esnext"]
   }
 }


### PR DESCRIPTION
When the client needed to wait for other clients it used the peer number instead of specific client ids. Now it uses player ids.