### PR TITLE
feat: fixing multiplayer experience

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,9 +29,11 @@
     "client": "node ./dist/client/index.js",
     "cli": "node ./dist/client/cli.js",
     "test": "vitest run --config vitest.config.ts --passWithNoTests",
-    "andres": "node --trace-uncaught ./dist/client/cli.js 'http://127.0.0.1:3000' 'Andres' 0 | tee -a /tmp/game_0",
-    "barto": "node --trace-uncaught ./dist/client/cli.js 'http://127.0.0.1:3000' 'Bartolomeo' 0 | tee -a /tmp/game_0",
-    "felipe": "node --trace-uncaught ./dist/client/cli.js 'http://127.0.0.1:3000' 'Felipe' 0 | tee -a /tmp/game_0"
+    "andres": "node --trace-uncaught ./dist/client/cli.js 'http://127.0.0.1:3000' 'Andres' 0 | tee -a /tmp/game_0 /tmp/andres.log",
+    "barto": "node --trace-uncaught ./dist/client/cli.js 'http://127.0.0.1:3000' 'Bartolomeo' 0 | tee -a /tmp/game_0 /tmp/barto.log",
+    "felipe": "node --trace-uncaught ./dist/client/cli.js 'http://127.0.0.1:3000' 'Felipe' 0 | tee -a /tmp/game_0 /tmp/felipe.log",
+    "pedro": "node --trace-uncaught ./dist/client/cli.js 'http://127.0.0.1:3000' 'Pedro' 0 | tee -a /tmp/game_0 /tmp/pedro.log",
+    "juan": "node --trace-uncaught ./dist/client/cli.js 'http://127.0.0.1:3000' 'Juan' 0 | tee -a /tmp/game_0 /tmp/juan.log"
   },
   "dependencies": {
     "eventemitter3": "^5.0.1",

--- a/packages/client/src/client/messageLog.ts
+++ b/packages/client/src/client/messageLog.ts
@@ -1,0 +1,48 @@
+import { GameMessage, GameMsg } from "../types/index.js";
+
+export class MessageKey {
+
+  constructor(
+    private readonly turn: number,
+    private readonly event: `${GameMsg}`,
+    private readonly sender: string,
+    private readonly recipient?: string,
+  ) {
+  }
+
+  toString() {
+    return `${this.turn}-${this.event}-${this.sender}-${this.recipient}`
+  }
+
+  static fromMsg(msg: GameMessage) {
+    return new this(msg.turn, msg.event, msg.sender, msg.to)
+  }
+
+}
+
+type Log<M extends GameMessage> = { [key: string]: M };
+
+export class MessageLog<M extends GameMessage> {
+
+  log: Log<M>;
+
+  constructor() {
+    this.log = {};
+  }
+
+  register(msg: M) {
+    const msgKey = MessageKey.fromMsg(msg);
+    this.log[msgKey.toString()] = msg;
+  }
+
+  find(turn: number, event: `${GameMsg}`, sender: string, to?: string): M | undefined {
+    const msgKey = new MessageKey(turn, event, sender, to);
+    return this.log[msgKey.toString()]
+  }
+
+  clear(msg: M) {
+    const msgKey = MessageKey.fromMsg(msg);
+    delete this.log[msgKey.toString()];
+  }
+
+}

--- a/packages/client/src/client/sockets/socketManager.ts
+++ b/packages/client/src/client/sockets/socketManager.ts
@@ -1,11 +1,26 @@
+import { EventEmitter } from "eventemitter3";
 import { io, Socket } from "socket.io-client";
 import { Player, TurnInfo } from "../../types/game.js";
-import { GameAnswerPayload, GameMsg, GameQueryPayload, GameReportPayload, GameUpdatePayload } from "../../types/gameMessages.js";
-import { GameAnswerMsg, GameQueryMsg, GameReportMsg, GameSocket, GameUpdateMsg } from "../../types/socket.interfaces.js";
-import { SetupSocketOptions, setupSockets } from "../setup.js";
+import {
+  GameAnswerMsg,
+  GameAnswerPayload,
+  GameMessage,
+  GameMsg,
+  GameQueryMsg,
+  GameQueryPayload,
+  GameReportMsg,
+  GameReportPayload,
+  GameUpdateMsg,
+  GameUpdatePayload
+} from "../../types/gameMessages.js";
+import { GameSocket } from "../../types/socket.interfaces.js";
 import { passTime, setEqual } from "../../utils.js";
-import { EventEmitter } from "eventemitter3";
+import { MessageLog } from "../messageLog.js";
+import { SetupSocketOptions } from "../setup.js";
 
+const TIMEOUT = 3_000;
+
+type FromTo = [string, string];
 
 export class SocketManager extends EventEmitter {
   game: GameSocket;
@@ -14,6 +29,7 @@ export class SocketManager extends EventEmitter {
   gameId: string;
 
   private _ready: boolean;
+  msgLog: MessageLog<GameMessage>;
 
   constructor(options: SetupSocketOptions) {
     super();
@@ -33,6 +49,7 @@ export class SocketManager extends EventEmitter {
     this.name = options.name;
     this.gameId = options.gameId
     this._ready = false;
+    this.msgLog = new MessageLog();
 
     const self = this;
 
@@ -46,10 +63,25 @@ export class SocketManager extends EventEmitter {
       ack();
     })
 
-    // this.game.on(GameMsg.WAITING, async (ack) => {
-    //   await self.emitWithAck(GameMsg.WAITING);
-    //   ack();
-    // })
+    this.game.on(GameMsg.QUERY, (msg: GameQueryMsg, ack: () => void) => {
+      this.msgLog.register(msg);
+      ack();
+    });
+
+    this.game.on(GameMsg.ANSWER, (msg: GameAnswerMsg, ack: () => void) => {
+      this.msgLog.register(msg);
+      ack();
+    });
+
+    this.game.on(GameMsg.UPDATE, (msg: GameUpdateMsg, ack: () => void) => {
+      this.msgLog.register(msg);
+      ack();
+    });
+
+    this.game.on(GameMsg.REPORT, (msg: GameReportMsg, ack: () => void) => {
+      this.msgLog.register(msg);
+      ack();
+    });
 
   }
 
@@ -90,6 +122,144 @@ export class SocketManager extends EventEmitter {
     }
   }
 
+  lookLogForEvent(turn: number, event: GameMsg, fromTo: Set<FromTo>): GameMessage[] {
+    return Array.from(fromTo.values().map(s => {
+      return this.msgLog.find(turn, event, s[0], s[1])
+    }).filter(x => x !== undefined))
+  }
+
+  lookLogForQueries(turn: number, fromTo: Set<FromTo>): GameQueryMsg[] {
+    return this.lookLogForEvent(turn, GameMsg.QUERY, fromTo) as GameQueryMsg[]
+  }
+
+  lookLogForAnswer(turn: number, fromTo: Set<FromTo>): GameAnswerMsg[] {
+    return this.lookLogForEvent(turn, GameMsg.ANSWER, fromTo) as GameAnswerMsg[]
+  }
+
+  lookLogForUpdates(turn: number, fromTo: Set<FromTo>): GameUpdateMsg[] {
+    return this.lookLogForEvent(turn, GameMsg.UPDATE, fromTo) as GameUpdateMsg[]
+  }
+
+  lookLogForReport(turn: number, from: string): GameReportMsg | undefined {
+    return this.msgLog.find(turn, GameMsg.REPORT, from) as GameReportMsg | undefined
+  }
+
+  async advertisePlayerAsReady() {
+    await this.game.timeout(TIMEOUT).emitWithAck(GameMsg.READY);
+  }
+
+  async broadcastAnswer(turn: number, to: string, payload: GameAnswerPayload) {
+    const answerMsg = {
+      turn,
+      event: GameMsg.ANSWER,
+      sender: this.sender,
+      to,
+      payload
+    };
+    await this.game.timeout(TIMEOUT).emitWithAck(GameMsg.ANSWER, answerMsg);
+  }
+
+  async broadcastQuery(turn: number, to: string, payload: GameQueryPayload) {
+    const queryMsg = {
+      turn,
+      event: GameMsg.QUERY,
+      sender: this.sender,
+      to,
+      payload
+    };
+    await this.game.timeout(TIMEOUT).emitWithAck(GameMsg.QUERY, queryMsg);
+  }
+
+  async broadcastUpdate(turn: number, to: string, payload: GameUpdatePayload) {
+    const updateMsg = {
+      turn,
+      event: GameMsg.UPDATE,
+      sender: this.sender,
+      to,
+      payload
+    };
+    await this.game.timeout(TIMEOUT).emitWithAck(GameMsg.UPDATE, updateMsg);
+  }
+
+  async broadcastReport(turn: number, payload: GameReportPayload) {
+    const reportMsg = {
+      turn,
+      event: GameMsg.REPORT,
+      sender: this.sender,
+      payload,
+    };
+    await this.game.timeout(TIMEOUT).emitWithAck(GameMsg.REPORT, reportMsg);
+  }
+
+  async waitForQuery(turn: number, activePlayer: string, players: Player[]): Promise<Map<string, GameQueryPayload>> {
+    const playerSet = new Set(players);
+    const queries: Map<Player, GameQueryPayload> = new Map();
+    return new Promise(async (res, rej) => {
+      setTimeout(rej, TIMEOUT);
+      while (true) {
+        await passTime(100);
+        const missingPlayers = new Set(playerSet.difference(new Set(queries.keys()))
+          .values()
+          .map(from => [from, activePlayer] as FromTo))
+        const loggedMsgs = this.lookLogForQueries(turn, missingPlayers);
+        loggedMsgs.forEach(msg => queries.set(msg.sender, msg.payload));
+        const enough = setEqual(playerSet, new Set(queries.keys()));
+        if (!enough) { await passTime(100); } else { break; }
+      }
+      res(queries)
+    });
+  }
+
+  async waitForAnswer(turn: number, activePlayer: Player, players: Player[]): Promise<Map<string, GameAnswerPayload>> {
+    const playerSet = new Set(players);
+    const answers: Map<Player, GameAnswerPayload> = new Map();
+    return new Promise(async (res, rej) => {
+      setTimeout(rej, TIMEOUT);
+      while (true) {
+        const missingPlayers = new Set(playerSet.difference(new Set(answers.keys()))
+          .values()
+          .map(from => [activePlayer, from] as FromTo))
+        const loggedMsgs = this.lookLogForAnswer(turn, missingPlayers);
+        loggedMsgs.forEach(msg => answers.set(msg.to, msg.payload));
+        const enough = setEqual(playerSet, new Set(answers.keys()));
+        if (!enough) { await passTime(100); } else { break; }
+      }
+      res(answers)
+    });
+  }
+
+  async waitForUpdates(turn: number, activePlayer: string, players: Player[]): Promise<Map<string, GameUpdatePayload>> {
+    const playerSet = new Set(players);
+    const updates: Map<Player, GameUpdatePayload> = new Map();
+    return new Promise(async (res, rej) => {
+      setTimeout(rej, TIMEOUT);
+      while (true) {
+        await passTime(100);
+        const missingPlayers = new Set(playerSet.difference(new Set(updates.keys()))
+          .values()
+          .map(from => [from, activePlayer] as FromTo))
+        const loggedMsgs = this.lookLogForUpdates(turn, missingPlayers);
+        loggedMsgs.forEach(msg => updates.set(msg.sender, msg.payload));
+        let enough = setEqual(playerSet, new Set(updates.keys()));
+        if (!enough) { await passTime(100); } else { break; }
+      }
+      res(updates)
+    });
+  }
+
+  async waitForReport(turn: number, from: Player): Promise<GameReportPayload> {
+    let report: GameReportPayload | undefined = undefined;
+    return new Promise(async (res, rej) => {
+      setTimeout(rej, TIMEOUT);
+      while (report === undefined) {
+        await passTime(100);
+        const reportMsg = this.lookLogForReport(turn, from);
+        report = reportMsg?.payload;
+      }
+      res(report)
+    });
+  }
+
   async waitForGameStartEvent(): Promise<void> {
     // TODO: add setTimeout to run rej branch
     return new Promise((res, rej) => {
@@ -101,129 +271,6 @@ export class SocketManager extends EventEmitter {
     // TODO: add setTimeout to run rej branch
     return new Promise((res, rej) => {
       this.game.once(GameMsg.TURN_START, (data: TurnInfo, ack) => { ack(); res(data) })
-    });
-  }
-
-  async advertisePlayerAsReady() {
-    await this.game.timeout(3000).emitWithAck(GameMsg.READY);
-  }
-
-  async broadcastAnswer(payload: GameAnswerPayload) {
-    const answerMsg = {
-      event: GameMsg.ANSWER,
-      sender: this.sender,
-      payload
-    };
-    await this.game.timeout(3000).emitWithAck(GameMsg.ANSWER, answerMsg);
-  }
-
-  async broadcastQuery(payload: GameQueryPayload) {
-    const queryMsg = {
-      event: GameMsg.QUERY,
-      sender: this.sender,
-      payload
-    };
-    await this.game.timeout(3000).emitWithAck(GameMsg.QUERY, queryMsg);
-  }
-
-  async broadcastUpdate(payload: GameUpdatePayload) {
-    const updateMsg = {
-      event: GameMsg.UPDATE,
-      sender: this.sender,
-      payload
-    };
-    await this.game.timeout(3000).emitWithAck(GameMsg.UPDATE, updateMsg);
-  }
-
-  async broadcastReport(payload: GameReportPayload) {
-    const reportMsg = {
-      event: GameMsg.REPORT,
-      sender: this.sender,
-      payload
-    };
-    await this.game.timeout(3000).emitWithAck(GameMsg.REPORT, reportMsg);
-  }
-
-  async waitForQuery(players: Player[]): Promise<Map<string, GameQueryPayload>> {
-
-    const playerSet = new Set(players);
-    const queries: Map<Player, GameQueryPayload> = new Map();
-
-
-    const listener = (msg: GameQueryMsg, ack: () => void) => {
-      queries.set(msg.sender, msg.payload)
-      ack();
-    };
-    this.game.on(GameMsg.QUERY, listener);
-
-    return new Promise(async (res, rej) => {
-      setTimeout(rej, 2000);
-      while (!setEqual(playerSet, new Set(queries.keys()))) {
-        await passTime(100);
-      }
-      this.game.off(GameMsg.QUERY, listener)
-      res(queries)
-    });
-  }
-
-  async waitForAnswer(players: Player[]): Promise<Map<string, GameAnswerPayload>> {
-    const playerSet = new Set(players);
-    const answers: Map<Player, GameAnswerPayload> = new Map();
-
-    const listener = (msg: GameAnswerMsg, ack: () => void) => {
-      answers.set(msg.payload.to, msg.payload)
-      ack();
-    };
-
-    this.game.on(GameMsg.ANSWER, listener);
-    return new Promise(async (res, rej) => {
-      while (!setEqual(playerSet, new Set(answers.keys()))) {
-        await passTime(100);
-      }
-      this.game.off(GameMsg.ANSWER, listener)
-      res(answers)
-    });
-  }
-
-  async waitForUpdates(players: Player[]): Promise<Map<string, GameUpdatePayload>> {
-
-    const playerSet = new Set(players);
-    const updates: Map<Player, GameUpdatePayload> = new Map();
-
-    const listener = (msg: GameUpdateMsg, ack: () => void) => {
-      // console.log("Received QUERY", msg);
-      updates.set(msg.sender, msg.payload)
-      ack();
-    };
-    this.game.on(GameMsg.UPDATE, listener);
-
-    return new Promise(async (res, rej) => {
-      setTimeout(rej, 2000);
-      while (!setEqual(playerSet, new Set(updates.keys()))) {
-        await passTime(100);
-      }
-      this.game.off(GameMsg.UPDATE, listener)
-      res(updates)
-    });
-  }
-
-
-  async waitForReport(from: Player): Promise<GameReportPayload> {
-    let report: GameReportPayload | undefined = undefined;
-    const listener = (msg: GameReportMsg, ack: () => void) => {
-      console.log("SOME REPORT MSG", JSON.stringify(msg));
-      if (msg.sender == from) {
-        report = msg.payload;
-      }
-      ack();
-    }
-    this.game.on(GameMsg.REPORT, listener);
-    return new Promise(async (res, rej) => {
-      while (report === undefined) {
-        await passTime(100);
-      }
-      this.game.off(GameMsg.REPORT, listener)
-      res(report)
     });
   }
 

--- a/packages/client/src/types/gameMessages.ts
+++ b/packages/client/src/types/gameMessages.ts
@@ -1,4 +1,5 @@
 import { Player } from "./game.js"
+import { Message } from "./messages.js"
 
 export enum GameMsg {
   DUMMY = "game:dummy",
@@ -34,3 +35,28 @@ export interface GameUpdatePayload extends GamePayload {
 
 export interface GameReportPayload extends GamePayload {
 }
+
+export interface IGameMessage extends Message {
+  event: `${GameMsg}`
+  turn: number
+  to?: Player
+}
+
+export interface GameQueryMsg extends IGameMessage {
+  payload: GameQueryPayload
+}
+
+export interface GameAnswerMsg extends IGameMessage {
+  payload: GameAnswerPayload
+  to: Player
+}
+
+export interface GameUpdateMsg extends IGameMessage {
+  payload: GameUpdatePayload
+}
+
+export interface GameReportMsg extends IGameMessage {
+  payload: GameReportPayload
+}
+
+export type GameMessage = GameQueryMsg | GameAnswerMsg | GameUpdateMsg | GameReportMsg

--- a/packages/client/src/types/socket.interfaces.ts
+++ b/packages/client/src/types/socket.interfaces.ts
@@ -1,27 +1,9 @@
 import { Socket } from "socket.io-client";
 import { TurnInfo } from "./game.js";
-import { GameAnswerPayload, GameMsg, GameQueryPayload, GameReportPayload, GameUpdatePayload } from "./gameMessages.js";
-import { Message } from "./messages.js";
+import { GameAnswerMsg, GameMsg, GameQueryMsg, GameReportMsg, GameUpdateMsg } from "./gameMessages.js";
 
 type Ack = () => void;
 
-export interface GameAnswerMsg extends Message {
-  // event: GameMsg.ANSWER,  // TODO: fix types
-  // event: `${GameMsg.ANSWER}`,
-  payload: GameAnswerPayload
-}
-
-export interface GameQueryMsg extends Message {
-  payload: GameQueryPayload
-}
-
-export interface GameUpdateMsg extends Message {
-  payload: GameUpdatePayload
-}
-
-export interface GameReportMsg extends Message {
-  payload: GameReportPayload
-}
 
 export interface GameNspClientToServerEvents {
   [GameMsg.DUMMY]: (...args: any[]) => void;

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -3,3 +3,8 @@ export function passTime(ms: number): Promise<void> {
     setTimeout(res, ms)
   })
 }
+
+export function setEqual<T>(set1: Set<T>, set2: Set<T>): boolean {
+  // we need compile option "lib": "esnext" for symmetricDifference
+  return set1.symmetricDifference(set2).size === 0
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -4,6 +4,6 @@
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "declaration": true,
-    "lib": ["dom"]
+    "lib": ["dom", "esnext"]
   }
 }

--- a/packages/gamemaster/src/sockets/game.ts
+++ b/packages/gamemaster/src/sockets/game.ts
@@ -22,13 +22,15 @@ export type GameSocket = Socket<
 
 function registerGameHandlers(socket: GameSocket) {
 
+  const TIMEOUT = 3_000;
+
   /*///////////////////////////////////////////////////////////////
                           BROADCASTING
   //////////////////////////////////////////////////////////////*/
   socket.on(GameMsg.QUERY, async (p: GameQueryMsg, ack: Ack) => {
     await socket
       .broadcast
-      .timeout(1000)
+      .timeout(TIMEOUT)
       .emitWithAck(GameMsg.QUERY, p);
     ack();
   })
@@ -36,7 +38,7 @@ function registerGameHandlers(socket: GameSocket) {
   socket.on(GameMsg.ANSWER, async (p: GameAnswerMsg, ack: Ack) => {
     await socket
       .broadcast
-      .timeout(1000)
+      .timeout(TIMEOUT)
       .emitWithAck(GameMsg.ANSWER, p);
     ack();
   });
@@ -44,7 +46,7 @@ function registerGameHandlers(socket: GameSocket) {
   socket.on(GameMsg.UPDATE, async (p: GameUpdateMsg, ack: Ack) => {
     await socket
       .broadcast
-      .timeout(1000)
+      .timeout(TIMEOUT)
       .emitWithAck(GameMsg.UPDATE, p);
     ack();
   });
@@ -52,7 +54,7 @@ function registerGameHandlers(socket: GameSocket) {
   socket.on(GameMsg.REPORT, async (p: GameReportMsg, ack: Ack) => {
     await socket
       .broadcast
-      .timeout(1000)
+      .timeout(TIMEOUT)
       .emitWithAck(GameMsg.REPORT, p);
     ack();
   });


### PR DESCRIPTION
Implemented a message registry (MessageLog) to hold on incoming messages. Messages are stored in a key-value structure where key is computed from the message attributes `$turn-$event-$sender-$recipient`, where `$recipient` can be optional, and the stored value is the entire message. Using this utility class we can poll for the correct messages for each step of the gameplay without worrying too much of race conditions. Messages will arrive sooner or later and they will be polled when needed.

This PR incorporates PR #18 so will close that one.
